### PR TITLE
Add RSS feed autodiscovery links

### DIFF
--- a/src/_includes/partials/head.njk
+++ b/src/_includes/partials/head.njk
@@ -55,4 +55,7 @@
   <!-- Fathom - beautiful, simple website analytics -->
   <script src="https://cdn.usefathom.com/script.js" data-site="AHYVTZHH" defer></script>
   <!-- / Fathom -->
+
+  <link rel="alternate" href="/feed.xml" title="The Blog of The 11ty Bundle" type="application/rss+xml">
+  <link rel="alternate" href="/firehosefeed.xml" title="The Firehose of The 11ty Bundle" type="application/rss+xml">
 </head>

--- a/src/pages/index.njk
+++ b/src/pages/index.njk
@@ -13,7 +13,7 @@ permalink: "/index.html"
 
 <p>If you're new to Eleventy, we've got links to more than 30 blog posts all about <a href="/categories/getting-started/">getting started</a>; and we've highlighted {{ bundledata.starterCount }} high-quality <a href="/starters/">starter projects</a> to choose from.</p>
 
-<p>There are two RSS feeds, <a href="/feed.xml">one for the 11tybundle.dev blog posts</a> and <a href="/firehosefeed.xml">one for the Firehose</a> with each post that has been collected and added to the collection of categorized posts.</p>
+<p>There are two RSS feeds, <a href="/feed.xml" rel="alternate" title="The Blog of The 11ty Bundle" type="application/rss+xml">one for the 11tybundle.dev blog posts</a> and <a href="/firehosefeed.xml" rel="alternate" title="The Firehose of The 11ty Bundle" type="application/rss+xml">one for the Firehose</a> with each post that has been collected and added to the collection of categorized posts.</p>
 </div>
 
 <a rel="me" href="https://indieweb.social/@bobmonsour" style="display: none">Mastodon</a>


### PR DESCRIPTION
Hello! First off, thanks for the great resource and hard work building and maintaining the 11ty Bundle website.

This is a small addition that adds autodiscovery link elements to the `head.njk` partial to facilitate RSS feed discovery via browser extensions, apps, etc.

Pretty straightforward markup addition. I also added similar HTML attributes to the existing anchors in the homepage copy. Those are slightly duplicative, but benign.

Thanks for considering this change!