### PR TITLE
B35 edits

### DIFF
--- a/src/posts/11ty-bundle-35.md
+++ b/src/posts/11ty-bundle-35.md
@@ -23,9 +23,9 @@ New on the docs: how to persist Eleventy Cache across builds to improve build ti
 
 If you've ever been looking for options to add forms to your static site, well [this CloudCannon page is for you](https://cloudcannon.com/jamstack-ecosystem/contact-forms/). I'd give you a count of all the options, but it's just too many to eyeball...and I'm in a hurry right now.
 
-## Eleventy Base Blog update
+## Eleventy Base WebC update
 
-The [Eleventy Base Blog using WebC](https://github.com/11ty/eleventy-base-webc) has been updated to Eleventy 3.0.0 using ESM. It's a great way to get your blogging started with Eleventy and WebC. It's just sitting there, waiting to be deployed.
+The [Eleventy Base WebC starter](https://github.com/11ty/eleventy-base-webc) has been updated to Eleventy 3.0.0 using ESM. It's a great way to get your blogging started with Eleventy and WebC. It's just sitting there, waiting to be deployed.
 
 ## Email or beer?
 

--- a/src/posts/11ty-bundle-35.md
+++ b/src/posts/11ty-bundle-35.md
@@ -25,7 +25,7 @@ If you've ever been looking for options to add forms to your static site, well [
 
 ## Eleventy Base WebC update
 
-The [Eleventy Base WebC starter](https://github.com/11ty/eleventy-base-webc) has been updated to Eleventy 3.0.0 using ESM. It's a great way to get your blogging started with Eleventy and WebC. It's just sitting there, waiting to be deployed.
+The [Eleventy Base WebC starter](https://github.com/11ty/eleventy-base-webc) has been updated to Eleventy 3.0.0 using ESM. It's a great way to get started with Eleventy and WebC. It's just sitting there, waiting to be deployed.
 
 ## Email or beer?
 


### PR DESCRIPTION
this is a deep cut kind of small note but technically the [base webc starter](https://github.com/11ty/eleventy-base-webc) is not a blog. [base *blog* is here](https://github.com/11ty/eleventy-base-blog) 

See https://eleventy-base-webc.pages.dev/ vs https://eleventy-base-blog.netlify.app/