### PR TITLE
Create filter for handling post/posts pluralization

### DIFF
--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -29,6 +29,7 @@ export default function (eleventyConfig) {
   eleventyConfig.addFilter("isCurrentPage", filters.isCurrentPage);
   eleventyConfig.addFilter("plainDate", filters.plainDate);
   eleventyConfig.addFilter("postCountByAuthor", filters.postCountByAuthor);
+  eleventyConfig.addFilter("postCountLabel", filters.postCountLabel);
   eleventyConfig.addFilter("postsByAuthor", filters.postsByAuthor);
   eleventyConfig.addFilter("postsInCategory", filters.postsInCategory);
   eleventyConfig.addFilter("readingTime", filters.readingTime);
@@ -53,7 +54,7 @@ export default function (eleventyConfig) {
     toFileDirectory: "bundle",
   });
 
-  eleventyConfig.setQuietMode(true);
+//   eleventyConfig.setQuietMode(true);
 
   return {
     markdownTemplateEngine: "njk",

--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -54,7 +54,7 @@ export default function (eleventyConfig) {
     toFileDirectory: "bundle",
   });
 
-//   eleventyConfig.setQuietMode(true);
+  eleventyConfig.setQuietMode(true);
 
   return {
     markdownTemplateEngine: "njk",

--- a/src/_config/filters.js
+++ b/src/_config/filters.js
@@ -10,6 +10,7 @@ import { getBundleItems } from "./filters/getbundleitems.js";
 import { getDescription } from "./filters/getdescription.js";
 import { getRSSlink } from "./filters/getrsslink.js";
 import { plainDate } from "./filters/formatting.js";
+import { postCountLabel } from "./filters/postcountlabel.js";
 import { postCountByAuthor, postsByAuthor } from "./filters/postsbyauthor.js";
 import { postsInCategory } from "./filters/postsincategory.js";
 import { readingTime } from "./filters/readingtime.js";
@@ -27,6 +28,7 @@ export default {
   getRSSlink,
   plainDate,
   postCountByAuthor,
+  postCountLabel,
   postsByAuthor,
   postsInCategory,
   readingTime,

--- a/src/_config/filters/postcountlabel.js
+++ b/src/_config/filters/postcountlabel.js
@@ -1,0 +1,4 @@
+// Generate post count label with proper pluralization
+export const postCountLabel = (count) => {
+  return count === 1 ? '1 post' : `${count} posts`;
+};

--- a/src/pages/authors.njk
+++ b/src/pages/authors.njk
@@ -1,7 +1,7 @@
 ---js
 {
   eleventyComputed: {
-    title: "{{ author[1] }} posts by {{ author[0] | safe }}",
+    title: "{{ author[1] | postCountLabel }} by {{ author[0] | safe }}",
     description: "Posts in the 11ty Bundle written by {{ author[0] }}",
     permalink: "/authors/{{ author[0] | cachedSlugify }}/",
   },


### PR DESCRIPTION
Howdy! I noticed with [Ethan Marcotte's new author page](https://11tybundle.dev/authors/ethan-marcotte/) that first-time Eleventy authors' pages will read "1 posts by..." - I figured I could come by and add some quick and dirty logic to handle singular/plural post counts on author titles.

Please feel free to ignore this altogether, or to tweak it to your preferences.

Thanks for building such a great community resource, Bob!