### PR TITLE
Deprecate webcbed in favor of 11ty/eleventy-base-webc

### DIFF
--- a/src/_data/bundledb.json
+++ b/src/_data/bundledb.json
@@ -16765,12 +16765,6 @@
   },
   {
     "Issue": "54",
-    "Type": "starter",
-    "Title": "WebC bed 🪸",
-    "Link": "https://github.com/rdela/webcbed"
-  },
-  {
-    "Issue": "54",
     "Type": "blog post",
     "Title": "Upgraded to Eleventy 3.0 (Beta)",
     "Link": "https://www.raymondcamden.com/2024/08/05/upgraded-to-eleventy-30-beta",


### PR DESCRIPTION
See https://github.com/rdela/webcbed/issues/8

Up to you of course, but I think https://github.com/11ty/eleventy-base-webc is a better bet all around for people looking to experiment.

Thanks Bob!!